### PR TITLE
Restore the spartan_parallel name

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "spartan"
+name = "spartan_parallel"
 version = "0.8.0"
 authors = ["Srinath Setty <srinath@microsoft.com>"]
 edition = "2021"


### PR DESCRIPTION
So that it's easy to have both the original Spartan and this package as dependencies.  Like we do for `ceno-recursion` at the moment.